### PR TITLE
Update UITableView+NXEmptyView.m

### DIFF
--- a/UITableView+NXEmptyView/UITableView+NXEmptyView.m
+++ b/UITableView+NXEmptyView/UITableView+NXEmptyView.m
@@ -20,9 +20,9 @@ void nxEV_swizzle(Class c, SEL orig, SEL new)
 {
     Method origMethod = class_getInstanceMethod(c, orig);
     Method newMethod = class_getInstanceMethod(c, new);
-    if(class_addMethod(c, orig, method_getImplementation(newMethod), method_getTypeEncoding(newMethod)))
+    if(class_addMethod(c, orig, method_getImplementation(newMethod), method_getTypeEncoding(newMethod))) {
         class_replaceMethod(c, new, method_getImplementation(origMethod), method_getTypeEncoding(origMethod));
-    else{
+    } else {
         method_exchangeImplementations(origMethod, newMethod);
         method_exchangeImplementations(newMethod, origMethod);
     }

--- a/UITableView+NXEmptyView/UITableView+NXEmptyView.m
+++ b/UITableView+NXEmptyView/UITableView+NXEmptyView.m
@@ -22,8 +22,10 @@ void nxEV_swizzle(Class c, SEL orig, SEL new)
     Method newMethod = class_getInstanceMethod(c, new);
     if(class_addMethod(c, orig, method_getImplementation(newMethod), method_getTypeEncoding(newMethod)))
         class_replaceMethod(c, new, method_getImplementation(origMethod), method_getTypeEncoding(origMethod));
-    else
+    else{
         method_exchangeImplementations(origMethod, newMethod);
+        method_exchangeImplementations(newMethod, origMethod);
+    }
 }
 
 


### PR DESCRIPTION
Fixing unit bug while testing.
For some reason while I execute the unit test target I run into a infinity  recursive call for `nxEV_reloadData`. I've found `class_addMethod` return false for this case and the else side was called. Even thought the original implementation wasn't been called anymore. 
`method_exchangeImplementations` doc says it exchanges implementations but in practice it is just change the implementation of the second param with the first one and not the other way around.
